### PR TITLE
Changed cloned repository to qedsoftware fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ opendronemap |Travis|
 
 Ansible version of `OpenDroneMap build script`_.
 
-.. _OpenDroneMap build script: https://github.com/OpenDroneMap/OpenDroneMap/blob/master/configure.sh
+.. _OpenDroneMap build script: https://github.com/qedsoftware/OpenDroneMap/blob/master/configure.sh
 
 Role Variables
 --------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Quantitative Engineering Design Inc.
 # All Rights Reserved.
 
-# Ansible port of script: https://github.com/OpenDroneMap/OpenDroneMap/blob/master/configure.sh
+# Ansible port of script: https://github.com/qedsoftware/OpenDroneMap/blob/master/configure.sh
 ---
 
 - command: which python
@@ -102,9 +102,9 @@
 
 - name: Clone OpenDroneMap repository {{ opendronemap_work_dir }}
   git:
-    repo=https://github.com/OpenDroneMap/OpenDroneMap
+    repo=https://github.com/qedsoftware/OpenDroneMap
     dest="{{ opendronemap_work_dir }}"
-    version=v0.1
+    version=29a537f9c6434e0b940b39ec23246fcbc16dcbbf
 
 - name: Create build directory
   file:


### PR DESCRIPTION
We have our fork of ODM containing fix for invalid tag processing
Version changed to SHA1 hash

https://github.com/qedsoftware/OpenDroneMap/commit/29a537f9c6434e0b940b39ec23246fcbc16dcbbf
